### PR TITLE
Fix webconsole

### DIFF
--- a/activemq-web/src/main/java/org/apache/activemq/web/BrokerFacadeSupport.java
+++ b/activemq-web/src/main/java/org/apache/activemq/web/BrokerFacadeSupport.java
@@ -240,8 +240,8 @@ public abstract class BrokerFacadeSupport implements BrokerFacade {
     public Collection<SubscriptionViewMBean> getQueueConsumers(String queueName) throws Exception {
         String brokerName = getBrokerName();
         queueName = StringUtils.replace(queueName, "\"", "_");
-        ObjectName query = new ObjectName("org.apache.activemq:type=Broker,brokerName=" + brokerName
-                + ",destinationType=Queue,destinationName=" + queueName + ",endpoint=Consumer,*");
+        ObjectName query = new ObjectName("org.apache.activemq:type=Broker,brokerName=\"" + brokerName
+                + "\",destinationType=Queue,destinationName=\"" + queueName + "\",endpoint=Consumer,*");
         Set<ObjectName> queryResult = queryNames(query, null);
         return getManagedObjects(queryResult.toArray(new ObjectName[queryResult.size()]), SubscriptionViewMBean.class);
     }
@@ -251,8 +251,8 @@ public abstract class BrokerFacadeSupport implements BrokerFacade {
     public Collection<ProducerViewMBean> getQueueProducers(String queueName) throws Exception {
         String brokerName = getBrokerName();
         queueName = StringUtils.replace(queueName, "\"", "_");
-        ObjectName query = new ObjectName("org.apache.activemq:type=Broker,brokerName=" + brokerName
-                + ",destinationType=Queue,destinationName=" + queueName + ",endpoint=Producer,*");
+        ObjectName query = new ObjectName("org.apache.activemq:type=Broker,brokerName=\"" + brokerName
+                + "\",destinationType=Queue,destinationName\"" + queueName + "\",endpoint=Producer,*");
         Set<ObjectName> queryResult = queryNames(query, null);
         return getManagedObjects(queryResult.toArray(new ObjectName[queryResult.size()]), ProducerViewMBean.class);
     }


### PR DESCRIPTION
By quoting queue names.

Issue:
Users are unable to see producers/consumers for that queue in console if queue name contains ":" (and some other symbols). So users get [frustrated](https://stackoverflow.com/questions/44817892/error-while-viewing-queue-consumers) for several years now.

The problem is that activemq/web uses jmx to query for consumers and producers of a queue.
And jmx [does not allow ](https://docs.oracle.com/javase/7/docs/api/javax/management/ObjectName.html) colons and some other symbols in queries. Queue name (and broker name) are _values_ and thus can (and should) be quoted.